### PR TITLE
Update draw.io to v27.1.6 and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Build and Upload Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build with Maven
+        run: mvn -B package
+      - name: Read project version
+        id: vars
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+      - name: Upload API jar
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: draw.io-api/target/draw.io-api-${{ steps.vars.outputs.version }}.jar
+          asset_name: draw.io-api-${{ steps.vars.outputs.version }}.jar
+          asset_content_type: application/java-archive
+      - name: Upload WebJar
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: draw.io-webjar/target/draw.io-${{ steps.vars.outputs.version }}.jar
+          asset_name: draw.io-${{ steps.vars.outputs.version }}.jar
+          asset_content_type: application/java-archive

--- a/draw.io-api/pom.xml
+++ b/draw.io-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.contrib</groupId>
     <artifactId>draw.io-parent</artifactId>
-    <version>24.5.5-4-SNAPSHOT</version>
+    <version>27.1.6-1-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <artifactId>draw.io-api</artifactId>

--- a/draw.io-webjar/pom.xml
+++ b/draw.io-webjar/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.contrib</groupId>
     <artifactId>draw.io-parent</artifactId>
-    <version>24.5.5-4-SNAPSHOT</version>
+    <version>27.1.6-1-SNAPSHOT</version>
   </parent>
   <artifactId>draw.io</artifactId>
   <packaging>webjar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <artifactId>draw.io-parent</artifactId>
   <packaging>pom</packaging>
   <name>draw.io Parent POM</name>
-  <version>24.5.5-4-SNAPSHOT</version>
+  <version>27.1.6-1-SNAPSHOT</version>
   <description>Provides packaging for the draw.io diagramming library.</description>
   <developers>
     <!-- Only for the packaging. The draw.io code is developed by JGraph Ltd. -->
@@ -46,7 +46,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>24.5.5</draw.io.version>
+    <draw.io.version>27.1.6</draw.io.version>
     <mxgraph.version>4.2.2_final</mxgraph.version>
     <draw.io-gliffy.version>13.4.8</draw.io-gliffy.version>
     <!-- The path to the folder where we unpack the draw.io sources. -->


### PR DESCRIPTION
## Summary
- update project to draw.io 27.1.6
- update modules to new parent version
- add a GitHub Actions workflow that builds on release and uploads jars as release assets

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855e535b51883218dd9eea990ea4340