### PR TITLE
Add sync workflows

### DIFF
--- a/.github/workflows/sync-drawio-sources.yml
+++ b/.github/workflows/sync-drawio-sources.yml
@@ -1,0 +1,26 @@
+name: Sync draw.io sources
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fetch upstream sources
+        run: |
+          git clone --depth 1 https://github.com/jgraph/drawio.git jgraph-drawio
+          rm -rf drawio-sources
+          mv jgraph-drawio drawio-sources
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: update draw.io sources from jgraph/drawio'
+          branch: update-drawio-sources
+          title: 'Update draw.io sources'
+          delete-branch: true
+          body: |
+            Automated update of draw.io sources from upstream repository.

--- a/.github/workflows/sync-package-builder.yml
+++ b/.github/workflows/sync-package-builder.yml
@@ -1,0 +1,26 @@
+name: Sync package builder
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fetch package builder
+        run: |
+          git clone --depth 1 https://github.com/seclution/draw.io.git package-builder
+          rm -rf builder-scripts
+          mv package-builder builder-scripts
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'chore: sync packaging builder from seclution/draw.io'
+          branch: update-package-builder
+          title: 'Update packaging builder'
+          delete-branch: true
+          body: |
+            Automated update of packaging builder from seclution/draw.io.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Provides packaging for the [draw.io](https://www.draw.io) diagramming library. T
 * Project Lead: [Marius Dumitru Florea](http://www.xwiki.org/xwiki/bin/view/XWiki/mflorea)
 * License: **Apache 2.0** license. Note that the packaged code (the draw.io library developed by JGraph Ltd) and some classes we modified (also developed by JGraph Ltd)  are licensed under Apache 2.0.
 * Continuous Integration Status: [![Build Status](http://ci.xwiki.org/job/XWiki%20Contrib/job/draw.io/job/master/badge/icon)](http://ci.xwiki.org/view/Contrib/job/XWiki%20Contrib/job/draw.io/job/master/)
+
+## GitHub Workflows
+
+This repository uses several GitHub Actions for automation:
+
+* **release.yml** builds and uploads the packaged artifacts when a release is published.
+* **sync-drawio-sources.yml** regularly pulls the upstream sources from [jgraph/drawio](https://github.com/jgraph/drawio) and opens a pull request with the updates.
+* **sync-package-builder.yml** keeps the packaging helper scripts in sync with [seclution/draw.io](https://github.com/seclution/draw.io).
+
+Both sync workflows run weekly and can also be triggered manually through the GitHub interface.


### PR DESCRIPTION
## Summary
- document workflow setup
- add workflow to sync draw.io sources
- add workflow to sync package builder

## Testing
- `mvn -B package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685608d22438832189584ac27f07f939